### PR TITLE
Patch PrioritizeChaCha to work with draft ciphers

### DIFF
--- a/openssl-1.1.1c-prioritize_chacha_draft.patch
+++ b/openssl-1.1.1c-prioritize_chacha_draft.patch
@@ -1,0 +1,34 @@
+--- a/ssl/s3_lib.c	2019-04-25 00:17:46.000000000 +0200
++++ b/ssl/s3_lib.c	2019-04-25 00:50:25.000000000 +0200
+@@ -4181,13 +4181,13 @@
+            temporarily prioritize all ChaCha20 ciphers in the servers list. */
+         if (s->options & SSL_OP_PRIORITIZE_CHACHA && sk_SSL_CIPHER_num(clnt) > 0) {
+             c = sk_SSL_CIPHER_value(clnt, 0);
+-            if (c->algorithm_enc == SSL_CHACHA20POLY1305) {
++            if (c->algorithm_enc & SSL_CHACHA20) {
+                 /* ChaCha20 is client preferred, check server... */
+                 int num = sk_SSL_CIPHER_num(srvr);
+                 int found = 0;
+                 for (i = 0; i < num; i++) {
+                     c = sk_SSL_CIPHER_value(srvr, i);
+-                    if (c->algorithm_enc == SSL_CHACHA20POLY1305) {
++                    if (c->algorithm_enc & SSL_CHACHA20) {
+                         found = 1;
+                         break;
+                     }
+@@ -4200,13 +4200,13 @@
+                         sk_SSL_CIPHER_push(prio_chacha, c);
+                         for (i++; i < num; i++) {
+                             c = sk_SSL_CIPHER_value(srvr, i);
+-                            if (c->algorithm_enc == SSL_CHACHA20POLY1305)
++                            if (c->algorithm_enc & SSL_CHACHA20)
+                                 sk_SSL_CIPHER_push(prio_chacha, c);
+                         }
+                         /* Pull in the rest */
+                         for (i = 0; i < num; i++) {
+                             c = sk_SSL_CIPHER_value(srvr, i);
+-                            if (c->algorithm_enc != SSL_CHACHA20POLY1305)
++                            if (!(c->algorithm_enc & SSL_CHACHA20))
+                                 sk_SSL_CIPHER_push(prio_chacha, c);
+                         }
+                         prio = prio_chacha;


### PR DESCRIPTION
This patch (authored by me) fixes PrioritizeChaCha to work with ChaCha20-Poly1305-Draft ciphers. 

It is only needed if the equal preference cipher grouping patch is not applied.

The patch needs to be applied on top of openssl-1.1.1c-chacha_draft.patch